### PR TITLE
Fix logo and icon url

### DIFF
--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -4,8 +4,8 @@ config:
   name: deepImageJ
   tags:
     - deepimagej
-  logo: "logos/logo.png"
-  icon: "logos/icon.png"
+  logo: https://raw.githubusercontent.com/deepimagej/models/master/logos/logo.png
+  icon: https://raw.githubusercontent.com/deepimagej/models/master/logos/icon.png
   splash_title: deepImageJ
   splash_subtitle: "A user-friendly plugin to run deep learning models in ImageJ"
   splash_feature_list:


### PR DESCRIPTION
The logo and icon url should be an absolute url to the raw file.