### PR TITLE
Remove Results.npy

### DIFF
--- a/defcon_density_map_estimation/model.yaml
+++ b/defcon_density_map_estimation/model.yaml
@@ -26,7 +26,6 @@ test_inputs:
   - ./exampleImage.npy
 test_outputs:
   - ./resultImage.npy
-  - ./Results.npy
 sample_inputs:
   - ./exampleImage.tif
 sample_outputs:


### PR DESCRIPTION
Results.npy does not exists, we had to remove it to make the model packager work.