### PR TITLE
Make deepimagej application passive

### DIFF
--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -31,6 +31,7 @@ application:
     icon: https://raw.githubusercontent.com/deepimagej/models/master/logos/icon.png
     documentation: https://deepimagej.github.io/deepimagej/index.html
     git_repo: https://github.com/deepimagej/deepimagej-plugin
+    passive: true
     tags:
       - deepimagej
       


### PR DESCRIPTION
This change is required for the new bioengine. Since the current deepimagej web site does not expose any imjoy api, we need to declear it as a passive application. The bioengine won't try to interact with it.