### PR TITLE
Verify bioimageio manifest with --auto-convert

### DIFF
--- a/.github/workflows/compile-manifest.yml
+++ b/.github/workflows/compile-manifest.yml
@@ -40,5 +40,5 @@ jobs:
 
       - name: Verify model config files
         run: |
-          pip install git+https://github.com/bioimage-io/python-bioimage-io.git
-          python -m bioimageio.spec verify-bioimageio-manifest manifest.bioimage.io.yaml
+          pip install git+https://github.com/bioimage-io/spec-bioimage-io.git
+          python -m bioimageio.spec verify-bioimageio-manifest --auto-convert manifest.bioimage.io.yaml

--- a/fru-net_sev_segmentation/model.yaml
+++ b/fru-net_sev_segmentation/model.yaml
@@ -20,7 +20,7 @@ tags:
   - extracellular vesicles
   - segmentation
   - TEM
-license: BSD-3
+license: BSD-3-Clause
 language: java
 framework: tensorflow
 test_inputs:


### PR DESCRIPTION
--auto-convert is a new option that converts model spec changes if automatically possible. This allows for slightly outdated models to pass the validation if no breaking changes have been introduced, because currently the validation is always done expecting the latest format version.

fixed problems with the fru-net_sev_segmentation model:
- [fixed through auto convert]: Authors with name and affiliation
- SPDX licence BSD-3 -> BSD-3-Clause (please confirm)
- exampleImage.npy was missing batch and channel dimension (as documented in model.yaml)

remaining problems with the fru-net_sev_segmentation model:
- [ ] spec 0.3.2 expects `documentation` to be a relative path to a markdown file, thus https://cbia.fi.muni.cz/research/segmentation/fru-net.html is invalid
