### PR TITLE
Add keys for supported_weight_formats

### DIFF
--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -34,6 +34,8 @@ application:
     passive: true
     tags:
       - deepimagej
+    config:
+      supported_weight_formats: ["tensorflow_saved_model_bundle"]
   - id: deepimagej-beta
     type: application
     name: DeepImageJ Beta
@@ -50,6 +52,9 @@ application:
     tags:
       - deepimagej-beta
       - deepimagej
+    config:
+      supported_weight_formats: ["tensorflow_saved_model_bundle", "pytorch_script"]
+
 workflow:
   - id: smlm-deepimagej
     type: workflow


### PR DESCRIPTION
To support the consumer icons in the packager, we need these additional keys. See discussion here: https://github.com/bioimage-io/spec-bioimage-io/issues/130